### PR TITLE
examples: use a better source of random

### DIFF
--- a/examples/mqtt_esp8266/mqtt_esp8266.ino
+++ b/examples/mqtt_esp8266/mqtt_esp8266.ino
@@ -1,5 +1,5 @@
 /*
- Basic ESP8266 MQTT example
+ Basic ESP8266 / ESP32 MQTT example
  This sketch demonstrates the capabilities of the pubsub library in combination
  with the ESP8266 board/library.
  It connects to an MQTT server then:
@@ -21,8 +21,8 @@
 #ifdef ESP8266
 #include <ESP8266WiFi.h>
 #elif defined(ESP32)
-#include <esp_random.h>
 #include <WiFi.h>
+#include <esp_random.h>
 #define BUILTIN_LED A0
 #define RANDOM_REG32 esp_random()
 #else

--- a/examples/mqtt_esp8266/mqtt_esp8266.ino
+++ b/examples/mqtt_esp8266/mqtt_esp8266.ino
@@ -56,7 +56,7 @@ void setup_wifi() {
         Serial.print(".");
     }
 
-    randomSeed(micros());
+    randomSeed(RANDOM_REG32);
 
     Serial.println("");
     Serial.println("WiFi connected");

--- a/examples/mqtt_esp8266/mqtt_esp8266.ino
+++ b/examples/mqtt_esp8266/mqtt_esp8266.ino
@@ -21,8 +21,10 @@
 #ifdef ESP8266
 #include <ESP8266WiFi.h>
 #elif defined(ESP32)
+#include <esp_random.h>
 #include <WiFi.h>
 #define BUILTIN_LED A0
+#define RANDOM_REG32 esp_random()
 #else
 #error Platform not supported.
 #endif

--- a/examples/mqtt_large_message/mqtt_large_message.ino
+++ b/examples/mqtt_large_message/mqtt_large_message.ino
@@ -1,5 +1,5 @@
 /*
- Long message ESP8266 MQTT example
+ Long message ESP8266 / ESP32 MQTT example
 
  This sketch demonstrates sending arbitrarily large messages in combination
  with the ESP8266 board/library.
@@ -26,8 +26,8 @@
 #ifdef ESP8266
 #include <ESP8266WiFi.h>
 #elif defined(ESP32)
-#include <esp_random.h>
 #include <WiFi.h>
+#include <esp_random.h>
 #define BUILTIN_LED A0
 #define RANDOM_REG32 esp_random()
 #else

--- a/examples/mqtt_large_message/mqtt_large_message.ino
+++ b/examples/mqtt_large_message/mqtt_large_message.ino
@@ -26,8 +26,10 @@
 #ifdef ESP8266
 #include <ESP8266WiFi.h>
 #elif defined(ESP32)
+#include <esp_random.h>
 #include <WiFi.h>
 #define BUILTIN_LED A0
+#define RANDOM_REG32 esp_random()
 #else
 #error Platform not supported.
 #endif
@@ -59,7 +61,7 @@ void setup_wifi() {
         Serial.print(".");
     }
 
-    randomSeed(micros());
+    randomSeed(RANDOM_REG32);
 
     Serial.println("");
     Serial.println("WiFi connected");


### PR DESCRIPTION
Use RANDOM_REG32 instead of micros() on ESP8266, using micros() is rather insecure.
Solves knolleary/pubsubclient#1054