### PR TITLE
Optimize __has_include

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -105,7 +105,7 @@
 // Maximum size of fixed header and variable length size header
 #define MQTT_MAX_HEADER_SIZE 5
 
-#if __has_include(<functional>) && !defined(NOFUNCTIONAL)
+#if defined(__has_include) && __has_include(<functional>) && !defined(NOFUNCTIONAL)
 #include <functional>
 /**
  * @brief Define the signature required by any callback function.


### PR DESCRIPTION
make use of functional more robust (e.g. with older compilers)