### PR TITLE
Refactor read* functions

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -253,7 +253,7 @@ bool PubSubClient::readByte(uint8_t* result) {
 bool PubSubClient::readByte(uint8_t* result, size_t* index) {
     uint8_t* write_address = &(result[*index]);
     if (readByte(write_address)) {
-        (*index)++;;
+        (*index)++;
         return true;
     }
     return false;

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -146,9 +146,9 @@ class PubSubClient : public Print {
     unsigned long lastInActivity;
     bool pingOutstanding;
     MQTT_CALLBACK_SIGNATURE;
-    uint32_t readPacket(uint8_t*);
+    size_t readPacket(uint8_t*);
     bool readByte(uint8_t* result);
-    bool readByte(uint8_t* result, uint16_t* index);
+    bool readByte(uint8_t* result, size_t* index);
     bool write(uint8_t header, uint8_t* buf, size_t length);
     size_t writeString(const char* string, uint8_t* buf, size_t pos);
     // Build up the header ready to send


### PR DESCRIPTION
+ added documentation on all private read* functions
+ refactored readPacket()
  - changed return type from uint32_t to size_t, as well as all relevant local variables 
  - replaced hard coded MQTT_MAX_HEADER_SIZE usages

+ refactored readByte()