### PR TITLE
Fix potential memory corruption in MQTTPUBLISH callback preparation

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -370,7 +370,7 @@ void PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
                         return;
                     }
                     uint16_t msgId = (this->buffer[payloadOffset] << 8) + this->buffer[payloadOffset + 1];
-                    callback(topic, payload + 2, payloadLen - 2); // remove the msgId from the callback payload
+                    callback(topic, payload + 2, payloadLen - 2);  // remove the msgId from the callback payload
 
                     this->buffer[0] = MQTTPUBACK;
                     this->buffer[1] = 2;

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -329,30 +329,48 @@ size_t PubSubClient::readPacket(uint8_t* lenLen) {
 /**
  * @brief  After a packet is read handle the content here (call the callback, handle pings)
  *
- * @param  llen Header length send by MQTT broker (1 .. MQTT_MAX_HEADER_SIZE - 1)
- * @param  len Number of read bytes in this->buffer
+ * @param  hdrLen Variable header length send by MQTT broker (1 .. MQTT_MAX_HEADER_SIZE - 1)
+ * @param  length Number of read bytes in this->buffer
  */
-void PubSubClient::handlePacket(uint8_t llen, size_t len) {
+void PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
     uint8_t type = this->buffer[0] & 0xF0;
     DEBUG_PSC_PRINTF("received message of type %u\n", type);
     switch (type) {
         case MQTTPUBLISH:
             if (callback) {
-                uint16_t topicLen = (this->buffer[llen + 1] << 8) + this->buffer[llen + 2];  // topic length in bytes
-                char* topic = (char*)(this->buffer + llen + 2);    // set the topic in the LSB of the topic lenght, as we move it there
-                uint16_t payloadOffset = llen + 1 + 2 + topicLen;  // payload starts after header and topic (if there is no packet identifier)
-                size_t payloadLen = len - payloadOffset;
+                // MQTT Publish packet: See section 3.3 MQTT v3.1 protocol specification:
+                // - Header: 1 byte
+                // - Remaining header length: hdrLen bytes, multibyte field (1 .. MQTT_MAX_HEADER_SIZE - 1)
+                // - Topic length: 2 bytes (starts at buffer[hdrLen + 1])
+                // - Topic: topicLen bytes (starts at buffer[hdrLen + 3])
+                // - Packet Identifier (msgId): 0 bytes for QoS 0, 2 bytes for QoS 1 and 2 (starts at buffer[hdrLen + 3 + topicLen])
+                // - Payload (for QoS = 0): length - (hdrLen + 3 + topicLen) bytes (starts at buffer[hdrLen + 3 + topicLen])
+                // - Payload (for QoS > 0): length - (hdrLen + 5 + topicLen) bytes (starts at buffer[hdrLen + 5 + topicLen])
+                // To get a null reminated 'C' topic string we move the topic 1 byte to the front (overwriting the LSB of the topic lenght)
+                uint16_t topicLen = (this->buffer[hdrLen + 1] << 8) + this->buffer[hdrLen + 2];  // topic length in bytes
+                char* topic = (char*)(this->buffer + hdrLen + 3 - 1);  // set the topic in the LSB of the topic lenght, as we move it there
+                uint16_t payloadOffset = hdrLen + 3 + topicLen;        // payload starts after header and topic (if there is no packet identifier)
+                size_t payloadLen = length - payloadOffset;            // this might change by 2 if we have a QoS 1 or 2 message
                 uint8_t* payload = this->buffer + payloadOffset;
 
-                if (len < payloadOffset) return;      // do not move outside the max bufferSize
+                if (length < payloadOffset) {  // do not move outside the max bufferSize
+                    ERROR_PSC_PRINTF_P("handlePacket(): Suspicious topicLen (%u) points outside of received buffer length (%zu)\n", topicLen, length);
+                    return;
+                }
                 memmove(topic, topic + 1, topicLen);  // move topic inside buffer 1 byte to front
                 topic[topicLen] = '\0';               // end the topic as a 'C' string with \x00
 
-                if ((this->buffer[0] & 0x06) == MQTTQOS1) {
-                    // msgId (packet identifier) is only present for QOS > 0
-                    if (payloadLen < 2) return;  // payload must be >= 2, as we have the msgId before
+                if ((this->buffer[0] & 0x06) == MQTTQOS0) {
+                    // No msgId for QOS == 0
+                    callback(topic, payload, payloadLen);
+                } else {
+                    // For QOS 1 and 2 we have a msgId (packet identifier) after the topic at the current payloadOffset
+                    if (payloadLen < 2) {  // payload must be >= 2, as we have the msgId before
+                        ERROR_PSC_PRINTF_P("handlePacket(): Missing msgId in QoS 1/2 message\n");
+                        return;
+                    }
                     uint16_t msgId = (this->buffer[payloadOffset] << 8) + this->buffer[payloadOffset + 1];
-                    callback(topic, payload + 2, payloadLen - 2);
+                    callback(topic, payload + 2, payloadLen - 2); // remove the msgId from the callback payload
 
                     this->buffer[0] = MQTTPUBACK;
                     this->buffer[1] = 2;
@@ -361,9 +379,6 @@ void PubSubClient::handlePacket(uint8_t llen, size_t len) {
                     if (_client->write(this->buffer, 4) == 4) {
                         lastOutActivity = millis();
                     }
-                } else {
-                    // No msgId for QOS == 0
-                    callback(topic, payload, payloadLen);
                 }
             }
             break;

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -166,7 +166,7 @@ class PubSubClient : public Print {
     Stream* stream;
     int _state;
 
-    void handlePacket(uint8_t hdrLen, size_t len);
+    bool handlePacket(uint8_t hdrLen, size_t len);
     size_t readPacket(uint8_t* hdrLen);
     bool readByte(uint8_t* result);
     bool readByte(uint8_t* result, size_t* pos);

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -123,12 +123,25 @@
         return false;                                              \
     }
 
+#ifdef DEBUG_ESP_PORT
 #ifdef DEBUG_PUBSUBCLIENT
-#ifndef DEBUG_PSC_PRINTF
-#define DEBUG_PSC_PRINTF(fmt, ...) Serial.printf(("PUBSUBCLIENT: " fmt), ##__VA_ARGS__)
-#endif
+#define DEBUG_PSC_PRINTF(fmt, ...) DEBUG_ESP_PORT.printf(("PubSubClient: " fmt), ##__VA_ARGS__)
 #else
 #define DEBUG_PSC_PRINTF(...)
+#endif
+
+#define ERROR_PSC_PRINTF(fmt, ...) DEBUG_ESP_PORT.printf(("PubSubClient error: " fmt), ##__VA_ARGS__)
+#define ERROR_PSC_PRINTF_P(fmt, ...) DEBUG_ESP_PORT.printf_P(PSTR("PubSubClient error: " fmt), ##__VA_ARGS__)
+#else  // DEBUG_ESP_PORT
+#ifndef DEBUG_PSC_PRINTF
+#define DEBUG_PSC_PRINTF(...)
+#endif
+#ifndef ERROR_PSC_PRINTF
+#define ERROR_PSC_PRINTF(fmt, ...)
+#endif
+#ifndef ERROR_PSC_PRINTF_P
+#define ERROR_PSC_PRINTF_P(fmt, ...)
+#endif
 #endif
 
 /**

--- a/tests/src/lib/Arduino.h
+++ b/tests/src/lib/Arduino.h
@@ -24,9 +24,11 @@ unsigned long millis(void);
 
 #define yield(x) {}
 
-#ifdef DEBUG_PUBSUBCLIENT
 #pragma GCC system_header
-#define DEBUG_PSC_PRINTF(fmt, ...) printf(("PUBSUBCLIENT: " fmt), ##__VA_ARGS__)
+#define ERROR_PSC_PRINTF(fmt, ...) printf(("PubSubClient error: " fmt), ##__VA_ARGS__)
+#define ERROR_PSC_PRINTF_P(fmt, ...) printf(("PubSubClient error: " fmt), ##__VA_ARGS__)
+#ifdef DEBUG_PUBSUBCLIENT
+#define DEBUG_PSC_PRINTF(fmt, ...) printf(("PubSubClient: " fmt), ##__VA_ARGS__)
 #endif
 
 #endif  // Arduino_h

--- a/tests/src/lib/Arduino.h
+++ b/tests/src/lib/Arduino.h
@@ -1,6 +1,7 @@
 #ifndef Arduino_h
 #define Arduino_h
 
+#include <cstdio>
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/src/lib/Arduino.h
+++ b/tests/src/lib/Arduino.h
@@ -1,11 +1,12 @@
 #ifndef Arduino_h
 #define Arduino_h
 
-#include <cstdio>
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include <cstdio>
 
 #include "Print.h"
 


### PR DESCRIPTION
This is a rework to make handling the received message more transparent.

Resolves #16 by checking against the given `len` that is checked in `readPacket()` to fit in `this->buffer[]`.