### PR TITLE
refactor beginPublish() and endPublish()

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -688,6 +688,9 @@ size_t PubSubClient::writeString(const char* string, uint8_t* buf, size_t pos, s
         buf[pos++] = (uint8_t)(sLen & 0xFF);
         memcpy(buf + pos, string, sLen);
         pos += sLen;
+    } else {
+        DEBUG_PSC_PRINTF("writeString(): string (%zu) does not fit into buf (%zu)\n", pos + 2 + sLen,
+                         size);  // TODO: change this to ERROR_PSC_PRINTF_P after #25 is merged
     }
     return pos;
 }

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -719,8 +719,7 @@ size_t PubSubClient::writeString(const char* string, uint8_t* buf, size_t pos, s
         memcpy(buf + pos, string, sLen);
         pos += sLen;
     } else {
-        DEBUG_PSC_PRINTF("writeString(): string (%zu) does not fit into buf (%zu)\n", pos + 2 + sLen,
-                         size);  // TODO: change this to ERROR_PSC_PRINTF_P after #25 is merged
+        ERROR_PSC_PRINTF_P("writeString(): string (%zu) does not fit into buf (%zu)\n", pos + 2 + sLen, size);
     }
     return pos;
 }

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -501,7 +501,7 @@ bool PubSubClient::beginPublish(const char* topic, size_t plength, bool retained
     if (connected() && MQTT_MAX_HEADER_SIZE + strlen(topic) + 2 <= this->bufferSize) {
         // first write the topic at the end of the maximal variable header (MQTT_MAX_HEADER_SIZE) to the buffer
         size_t topicLen = writeString(topic, this->buffer, MQTT_MAX_HEADER_SIZE) - MQTT_MAX_HEADER_SIZE;
-        // we now know the length of the topic and can build the variable header information
+        // we now know the length of the topic string (lenght + 2 bytes signalling the length) and can build the variable header information
         const uint8_t header = MQTTPUBLISH | (retained ? MQTTRETAINED : 0);
         uint8_t hdrLen = buildHeader(header, this->buffer, topicLen + plength);
         // as the header length is variable, it starts at MQTT_MAX_HEADER_SIZE - hdrLen (see buildHeader() documentation)

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -159,6 +159,7 @@ class PubSubClient : public Print {
     bool readByte(uint8_t* result, size_t* pos);
     bool write(uint8_t header, uint8_t* buf, size_t length);
     size_t writeString(const char* string, uint8_t* buf, size_t pos);
+    size_t writeString(const char* string, uint8_t* buf, size_t pos, size_t size);
     uint8_t buildHeader(uint8_t header, uint8_t* buf, size_t length);
 
    public:

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -510,6 +510,7 @@ class PubSubClient : public Print {
      * a new buffer and held in memory at one time.
      * @param topic The topic to publish to.
      * @param plength The length of the payload.
+     * @param retained Publish the message with the retain flag.
      * @return true If the publish succeeded.
      * false If the publish failed, either connection lost or message too large.
      */

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -508,7 +508,6 @@ class PubSubClient : public Print {
      * Allows for arbitrarily large payloads to be sent without them having to be copied into
      * a new buffer and held in memory at one time.
      * @param topic The topic to publish to.
-     * @param payload The message to publish.
      * @param plength The length of the payload.
      * @return true If the publish succeeded.
      * false If the publish failed, either connection lost or message too large.
@@ -520,7 +519,7 @@ class PubSubClient : public Print {
      * @return true If the publish succeeded.
      * false If the publish failed, either connection lost or message too large.
      */
-    int endPublish();
+    bool endPublish();
 
     /**
      * @brief Writes a single byte as a component of a publish started with a call to beginPublish.

--- a/tests/src/publish_spec.cpp
+++ b/tests/src/publish_spec.cpp
@@ -186,7 +186,7 @@ int test_publish_P() {
 }
 
 int test_publish_P_too_long() {
-    IT("publish using PROGMEM fails when topic/payload are too long");
+    IT("publish using PROGMEM fails when topic are too long");
     ShimClient shimClient;
     shimClient.setAllowConnect(true);
 

--- a/tests/src/publish_spec.cpp
+++ b/tests/src/publish_spec.cpp
@@ -15,6 +15,7 @@ int test_publish_retained_2();
 int test_publish_not_connected();
 int test_publish_too_long();
 int test_publish_P();
+int test_publish_P_too_long();
 
 void callback(char* topic, uint8_t* payload, size_t length) {
     // handle message arrived

--- a/tests/src/publish_spec.cpp
+++ b/tests/src/publish_spec.cpp
@@ -148,7 +148,7 @@ int test_publish_too_long() {
     bool rc = client.connect("client_test1");
     IS_TRUE(rc);
 
-    //                                         0        1         2         3         4         5         6         7         8         9         0 1 2
+    //                   0        1         2         3         4         5         6         7         8         9         0         1         2
     rc = client.publish("topic",
                         "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890");
     IS_FALSE(rc);
@@ -184,6 +184,33 @@ int test_publish_P() {
     END_IT
 }
 
+int test_publish_P_too_long() {
+    IT("publish using PROGMEM fails when topic/payload are too long");
+    ShimClient shimClient;
+    shimClient.setAllowConnect(true);
+
+    //              0        1         2         3         4         5         6         7         8         9         0         1         2
+    char topic[] = "1234567890123456789012345678901234567890123456789012345678901234";
+
+    //                0        1         2         3         4         5         6         7         8         9         0         1         2
+    char payload[] = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
+
+    byte connack[] = {0x20, 0x02, 0x00, 0x00};
+    shimClient.respond(connack, 4);
+
+    PubSubClient client(server, 1883, callback, shimClient);
+    client.setBufferSize(64);
+    bool rc = client.connect("client_test1");
+    IS_TRUE(rc);
+
+    rc = client.publish_P(topic, payload, false);
+    IS_FALSE(rc);
+
+    IS_FALSE(shimClient.error());
+
+    END_IT
+}
+
 int main() {
     SUITE("Publish");
     test_publish();
@@ -193,6 +220,7 @@ int main() {
     test_publish_not_connected();
     test_publish_too_long();
     test_publish_P();
+    test_publish_P_too_long();
 
     FINISH
 }


### PR DESCRIPTION
* beginPublish(): tried to implement it simpler and easier to understand
* endPublish() changed return type from `int` to `bool` as, documented in the [API](https://pubsubclient.knolleary.net/api#endPublish)