### PR TITLE
Refactor publish()

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -439,7 +439,7 @@ class PubSubClient : public Print {
     void disconnect();
 
     /**
-     * @brief Publishes a message to the specified topic.
+     * @brief Publishes a non retained message to the specified topic.
      * @param topic The topic to publish to.
      * @param payload The message to publish.
      * @return true If the publish succeeded.
@@ -458,7 +458,7 @@ class PubSubClient : public Print {
     bool publish(const char* topic, const char* payload, bool retained);
 
     /**
-     * @brief Publishes a message to the specified topic.
+     * @brief Publishes a non retained message to the specified topic.
      * @param topic The topic to publish to.
      * @param payload The message to publish.
      * @param plength The length of the payload.

--- a/tests/src/publish_spec.cpp
+++ b/tests/src/publish_spec.cpp
@@ -140,17 +140,21 @@ int test_publish_too_long() {
     ShimClient shimClient;
     shimClient.setAllowConnect(true);
 
+    //              0        1         2         3         4         5         6         7         8         9         0         1         2
+    char topic[] = "1234567890123456789012345678901234567890123456789012345678901234";
+
+    //                0        1         2         3         4         5         6         7         8         9         0         1         2
+    char payload[] = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
+
     byte connack[] = {0x20, 0x02, 0x00, 0x00};
     shimClient.respond(connack, 4);
 
     PubSubClient client(server, 1883, callback, shimClient);
-    client.setBufferSize(128);
+    client.setBufferSize(64);
     bool rc = client.connect("client_test1");
     IS_TRUE(rc);
 
-    //                                         0        1         2         3         4         5         6         7         8         9         0 1 2
-    rc = client.publish("topic",
-                        "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890");
+    rc = client.publish(topic, payload);
     IS_FALSE(rc);
 
     IS_FALSE(shimClient.error());


### PR DESCRIPTION
Simplifying `publish()` by using existing functions `beginPublish()`, `write()` and `endPublish()`.
Doing this allows sending big payloads without increasing buffer size.
Resolves #29 