### PR TITLE
Refactor keepAlive to millis

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -166,7 +166,7 @@ bool PubSubClient::connect(const char* id, const char* user, const char* pass, c
                     v = v | (0x80 >> 1);
                 }
             }
-            uint16_t keepAlive = this->keepAliveMillis / 1000;
+            const uint16_t keepAlive = this->keepAliveMillis / 1000;
             this->buffer[length++] = v;
             this->buffer[length++] = keepAlive >> 8;
             this->buffer[length++] = keepAlive & 0xFF;
@@ -409,7 +409,7 @@ bool PubSubClient::loop() {
         return false;
     }
     bool ret = true;
-    unsigned long t = millis();
+    const unsigned long t = millis();
     if (keepAliveMillis && ((t - lastInActivity > this->keepAliveMillis) || (t - lastOutActivity > this->keepAliveMillis))) {
         if (pingOutstanding) {
             DEBUG_PSC_PRINTF("loop aborting due to timeout\n");

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -7,8 +7,7 @@
 
 #include "PubSubClient.h"
 
-PubSubClient::PubSubClient()
-    : _client(nullptr), bufferSize(0), callback(nullptr), domain(nullptr), port(0), stream(nullptr), _state(MQTT_DISCONNECTED) {
+PubSubClient::PubSubClient() : _client(nullptr), bufferSize(0), callback(nullptr), domain(nullptr), port(0), stream(nullptr), _state(MQTT_DISCONNECTED) {
     setBufferSize(MQTT_MAX_PACKET_SIZE);
     setSocketTimeout(MQTT_SOCKET_TIMEOUT);
     setKeepAlive(MQTT_KEEPALIVE);

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -153,7 +153,7 @@ class PubSubClient : public Print {
     Client* _client;
     uint8_t* buffer;
     size_t bufferSize;
-    uint16_t keepAlive;
+    unsigned long keepAliveMillis;
     uint16_t socketTimeout;
     uint16_t nextMsgId;
     unsigned long lastOutActivity;

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -359,6 +359,7 @@ class PubSubClient : public Print {
     /**
      * @brief Sets the keep alive interval used by the client.
      * This value should only be changed when the client is not connected.
+     * Set keepAlive to zero (0) to turn off the keep alive mechanism.
      * @param keepAlive The keep alive interval, in seconds.
      * @return The client instance, allowing the function to be chained.
      */


### PR DESCRIPTION
Optimize loop() to avoid multiply by 1000 in every cyclic call ...
Check keepAliveMillis first, to skip time check if keepAlive is deactivated.