### PR TITLE
Optimize tests

### DIFF
--- a/tests/src/connect_spec.cpp
+++ b/tests/src/connect_spec.cpp
@@ -23,11 +23,8 @@ int test_connect_with_will_username_password();
 int test_connect_disconnect_connect();
 int test_connect_custom_keepalive();
 
-void callback(char* topic, uint8_t* payload, size_t length) {
+void callback(_UNUSED_ char* topic, _UNUSED_ uint8_t* payload, _UNUSED_ size_t length) {
     // handle message arrived
-    topic[0];
-    payload[0];
-    length;
 }
 
 int test_connect_fails_no_network() {

--- a/tests/src/keepalive_spec.cpp
+++ b/tests/src/keepalive_spec.cpp
@@ -16,11 +16,8 @@ int test_keepalive_pings_with_inbound_qos0();
 int test_keepalive_no_pings_inbound_qos1();
 int test_keepalive_disconnects_hung();
 
-void callback(char* topic, uint8_t* payload, size_t length) {
+void callback(_UNUSED_ char* topic, _UNUSED_ uint8_t* payload, _UNUSED_ size_t length) {
     // handle message arrived
-    topic[0];
-    payload[0];
-    length;
 }
 
 int test_keepalive_pings_idle() {

--- a/tests/src/lib/Arduino.h
+++ b/tests/src/lib/Arduino.h
@@ -33,4 +33,6 @@ unsigned long millis(void);
 #define DEBUG_PSC_PRINTF(fmt, ...) printf(("PubSubClient: " fmt), ##__VA_ARGS__)
 #endif
 
+#define _UNUSED_ __attribute__((unused))
+
 #endif  // Arduino_h

--- a/tests/src/publish_spec.cpp
+++ b/tests/src/publish_spec.cpp
@@ -17,11 +17,8 @@ int test_publish_too_long();
 int test_publish_P();
 int test_publish_P_too_long();
 
-void callback(char* topic, uint8_t* payload, size_t length) {
+void callback(_UNUSED_ char* topic, _UNUSED_ uint8_t* payload, _UNUSED_ size_t length) {
     // handle message arrived
-    topic[0];
-    payload[0];
-    length;
 }
 
 int test_publish() {

--- a/tests/src/subscribe_spec.cpp
+++ b/tests/src/subscribe_spec.cpp
@@ -16,11 +16,8 @@ int test_subscribe_too_long();
 int test_unsubscribe();
 int test_unsubscribe_not_connected();
 
-void callback(char* topic, uint8_t* payload, size_t length) {
+void callback(_UNUSED_ char* topic, _UNUSED_ uint8_t* payload, _UNUSED_ size_t length) {
     // handle message arrived
-    topic[0];
-    payload[0];
-    length;
 }
 
 int test_subscribe_no_qos() {


### PR DESCRIPTION
use `__attribute__((unused))` instead of accessing the parameter