### PR TITLE
Add check for nullptr in CHECK_STRING_LENGTH

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -117,10 +117,10 @@
 #define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, size_t)
 #endif
 
-#define CHECK_STRING_LENGTH(l, s)                                  \
-    if (l + 2 + strnlen(s, this->bufferSize) > this->bufferSize) { \
-        _client->stop();                                           \
-        return false;                                              \
+#define CHECK_STRING_LENGTH(l, s)                                            \
+    if ((!s) || (l + 2 + strnlen(s, this->bufferSize) > this->bufferSize)) { \
+        _client->stop();                                                     \
+        return false;                                                        \
     }
 
 #ifdef DEBUG_ESP_PORT


### PR DESCRIPTION
`strnlen` will cause a crash when called with a nullptr. Where this macro is called, there are already some checks for optional fields, however it is a bit 'not so nice' for the device to crash when accidentally a nullptr is given for for example the id or will message.  (will topic is checked, will message is not)