### PR TITLE
move CHECK_STRING_LENGTH to PubSubClient.cpp

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -7,6 +7,19 @@
 
 #include "PubSubClient.h"
 
+/**
+ * @brief Macro to check if a string 's' can be safely added to the MQTT buffer.
+ *
+ * If either check fails, the client connection is stopped and the function returns false.
+ * @param l current length in the buffer
+ * @param s string to check
+ */
+#define CHECK_STRING_LENGTH(l, s)                                            \
+    if ((!s) || (l + 2 + strnlen(s, this->bufferSize) > this->bufferSize)) { \
+        _client->stop();                                                     \
+        return false;                                                        \
+    }
+
 PubSubClient::PubSubClient() {
     setBufferSize(MQTT_MAX_PACKET_SIZE);
     setKeepAlive(MQTT_KEEPALIVE);

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -117,12 +117,6 @@
 #define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, size_t)
 #endif
 
-#define CHECK_STRING_LENGTH(l, s)                                            \
-    if ((!s) || (l + 2 + strnlen(s, this->bufferSize) > this->bufferSize)) { \
-        _client->stop();                                                     \
-        return false;                                                        \
-    }
-
 #ifdef DEBUG_ESP_PORT
 #ifdef DEBUG_PUBSUBCLIENT
 #define DEBUG_PSC_PRINTF(fmt, ...) DEBUG_ESP_PORT.printf(("PubSubClient: " fmt), ##__VA_ARGS__)


### PR DESCRIPTION
Do not expose the internal macro CHECK_STRING_LENGTH to the public.