### PR TITLE
[PubSubClient3] Speedup publish large messages using buffer

### DIFF
--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -190,6 +190,7 @@ class PubSubClient : public Print {
     uint16_t port{};
     Stream* stream{};
     int _state{MQTT_DISCONNECTED};
+    int _bufferWritePos = 0;
     uint8_t _qos{MQTT_QOS0};
 
     size_t readPacket(uint8_t* hdrLen);
@@ -200,6 +201,12 @@ class PubSubClient : public Print {
     bool write(uint8_t header, uint8_t* buf, size_t length);
     size_t writeString(const char* string, uint8_t* buf, size_t pos, size_t size);
     size_t writeNextMsgId(uint8_t* buf, size_t pos, size_t size);
+
+
+    // Add to buffer and flush if full (only to be used with beginPublish/endPublish)Add commentMore actions
+    size_t appendBuffer(uint8_t data);
+    size_t appendBuffer(const uint8_t *data, size_t size);
+    size_t flushBuffer();
 
    public:
     /**
@@ -638,6 +645,8 @@ class PubSubClient : public Print {
 
     /**
      * @brief Writes a single byte as a component of a publish started with a call to beginPublish.
+     *        For performance reasons, this will be appended to the internal buffer, 
+     *        which will be flushed when full or on a call to endPublish().
      * @param data A byte to write to the publish payload.
      * @return The number of bytes written.
      */
@@ -645,7 +654,8 @@ class PubSubClient : public Print {
 
     /**
      * @brief Writes an array of bytes as a component of a publish started with a call to beginPublish.
-     * @param buffer The bytes to write.
+     *        For performance reasons, this will be appended to the internal buffer, 
+     *        which will be flushed when full or on a call to endPublish().     * @param buffer The bytes to write.
      * @param size The length of the payload to be sent.
      * @return The number of bytes written.
      */


### PR DESCRIPTION
As discussed here: hmueller01/pubsubclient3#29 (comment)


Not yet tested, as I really need to get some sleep now...

My biggest concern right now is whether `writeNextMsgId` might also need to call `flushBuffer()` first.
But as I said, can't think clearly right now so if you can have a look @hmueller01 