### PR TITLE
Function parameter code update

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -639,9 +639,9 @@ size_t PubSubClient::write(uint8_t data) {
     return _client->write(data);
 }
 
-size_t PubSubClient::write(const uint8_t* buffer, size_t size) {
+size_t PubSubClient::write(const uint8_t* buf, size_t size) {
     lastOutActivity = millis();
-    return _client->write(buffer, size);
+    return _client->write(buf, size);
 }
 
 /**

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -645,11 +645,11 @@ class PubSubClient : public Print {
 
     /**
      * @brief Writes an array of bytes as a component of a publish started with a call to beginPublish.
-     * @param buffer The bytes to write.
+     * @param buf The bytes to write.
      * @param size The length of the payload to be sent.
      * @return The number of bytes written.
      */
-    virtual size_t write(const uint8_t* buffer, size_t size);
+    virtual size_t write(const uint8_t* buf, size_t size);
 
     /**
      * @brief Subscribes to messages published to the specified topic using QoS 0.


### PR DESCRIPTION
always use `buf` (not `buffer`) in function parameter list