### PR TITLE
Add buffer safety checks to prevent out-of-bounds access

### DIFF
--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -113,6 +113,7 @@ PubSubClient::~PubSubClient() {
 bool PubSubClient::connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, bool willRetain,
                            const char* willMessage, bool cleanSession) {
     if (!_client) return false;  // do not crash if client not set
+    if (!_buffer) return false;  // do not crash if buffer allocation failed at construction
     if (!connected()) {
         int result = 0;
 
@@ -231,7 +232,7 @@ bool PubSubClient::connected() {
 void PubSubClient::disconnect() {
     DEBUG_PSC_PRINTF("disconnect called\n");
     _state = MQTT_DISCONNECTED;
-    if (_client) {
+    if (_client && _buffer) {  // guard against null buffer if allocation failed at construction
         _buffer[0] = MQTTDISCONNECT;
         _buffer[1] = 0;
         _client->write(_buffer, 2);
@@ -371,14 +372,20 @@ bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
                 // - Payload (for QoS = 0): length - (hdrLen + 3 + topicLen) bytes (starts at _buffer[hdrLen + 3 + topicLen])
                 // - Payload (for QoS > 0): length - (hdrLen + 5 + topicLen) bytes (starts at _buffer[hdrLen + 5 + topicLen])
                 // To get a null reminated 'C' topic string we move the topic 1 byte to the front (overwriting the LSB of the topic lenght)
+                // Guard 1: ensure topic length bytes are readable
+                if ((hdrLen + 2ul >= length) || (hdrLen + 2ul >= _bufferSize)) {
+                    ERROR_PSC_PRINTF_P("handlePacket(): Packet too short to contain topic length field\n");
+                    return false;
+                }
                 uint16_t topicLen = (_buffer[hdrLen + 1] << 8) + _buffer[hdrLen + 2];  // topic length in bytes
                 char* topic = (char*)(_buffer + hdrLen + 3 - 1);                       // set the topic in the LSB of the topic lenght, as we move it there
-                uint16_t payloadOffset = hdrLen + 3 + topicLen;  // payload starts after header and topic (if there is no packet identifier)
+                size_t payloadOffset = hdrLen + 3ul + topicLen;  // payload starts after header and topic (if there is no packet identifier)
                 size_t payloadLen = length - payloadOffset;      // this might change by 2 if we have a QoS 1 or 2 message
                 uint8_t* payload = _buffer + payloadOffset;
 
-                if (length < payloadOffset) {  // do not move outside the max bufferSize
-                    ERROR_PSC_PRINTF_P("handlePacket(): Suspicious topicLen (%u) points outside of received buffer length (%zu)\n", topicLen, length);
+                // Guard 2: ensure topic and payload fit in buffer
+                if ((payloadOffset > _bufferSize) || (payloadOffset > length)) {
+                    ERROR_PSC_PRINTF_P("handlePacket(): Topic extends outside buffer/data\n");
                     return false;
                 }
                 memmove(topic, topic + 1, topicLen);  // move topic inside buffer 1 byte to front
@@ -389,8 +396,9 @@ bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
                     callback(topic, payload, payloadLen);
                 } else {
                     // For QOS 1 and 2 we have a msgId (packet identifier) after the topic at the current payloadOffset
-                    if (payloadLen < 2) {  // payload must be >= 2, as we have the msgId before
-                        ERROR_PSC_PRINTF_P("handlePacket(): Missing msgId in QoS 1/2 message\n");
+                    // Guard 3: msgId must be addressable
+                    if ((payloadLen < 2) || (payloadOffset + 1 >= _bufferSize)) {
+                        ERROR_PSC_PRINTF_P("handlePacket(): Missing or out-of-bounds msgId in QoS 1/2\n");
                         return false;
                     }
                     uint8_t publishQos = MQTT_HDR_GET_QOS(_buffer[0]);  // save QoS before _buffer[0] is overwritten
@@ -473,6 +481,13 @@ bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
 
 bool PubSubClient::loop() {
     if (!connected()) {
+        return false;
+    }
+    // Guard: buffer must exist and be large enough to hold any minimal MQTT packet
+    // (e.g. PINGREQ is 2 bytes, PUBACK/PUBREC responses are 4 bytes).
+    // This prevents readPacket() and handlePacket() from ever running with a null or
+    // undersized buffer. Note: MQTT_MAX_HEADER_SIZE (5) covers the worst-case fixed header.
+    if ((!_buffer) || (_bufferSize < MQTT_MAX_HEADER_SIZE)) {
         return false;
     }
     bool ret = true;

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -361,7 +361,7 @@ bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
     uint8_t type = _buffer[0] & 0xF0;
     DEBUG_PSC_PRINTF("handlePacket(): received message of type %u\n", type);
     if (length > _bufferSize) {
-        // This should never happen as readPacket() prevents buffer overflow, but we check again here to be sure and prevent any buffer overflows in the handling code.
+        // This should never happen as readPacket() prevents buffer overflow, but we check again here to be sure and prevent any buffer overflows.
         DEBUG_PSC_PRINTF("handlePacket(): packet length %zu exceeds buffer size %zu\n", length, _bufferSize);
         return false;
     }

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -376,7 +376,7 @@ bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
                 // - Packet Identifier (msgId): 0 bytes for QoS 0, 2 bytes for QoS 1 and 2 (starts at _buffer[hdrLen + 3 + topicLen])
                 // - Payload (for QoS = 0): length - (hdrLen + 3 + topicLen) bytes (starts at _buffer[hdrLen + 3 + topicLen])
                 // - Payload (for QoS > 0): length - (hdrLen + 5 + topicLen) bytes (starts at _buffer[hdrLen + 5 + topicLen])
-                // To get a null reminated 'C' topic string we move the topic 1 byte to the front (overwriting the LSB of the topic lenght)
+                // To get a null terminated 'C' topic string we move the topic 1 byte to the front (overwriting the LSB of the topic lenght)
                 // Guard 1: ensure topic length bytes are readable
                 if (hdrLen + 3ul > length) {
                     DEBUG_PSC_PRINTF("handlePacket(): Packet too short to contain topic length field\n");

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -378,7 +378,7 @@ bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
                 // - Payload (for QoS > 0): length - (hdrLen + 5 + topicLen) bytes (starts at _buffer[hdrLen + 5 + topicLen])
                 // To get a null terminated 'C' topic string we move the topic 1 byte to the front (overwriting the LSB of the topic lenght)
                 // Guard 1: ensure topic length bytes are readable
-                if (hdrLen + 3ul > length) {
+                if (length < hdrLen + 3ul) {
                     DEBUG_PSC_PRINTF("handlePacket(): Packet too short to contain topic length field\n");
                     return false;
                 }

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -401,9 +401,8 @@ bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
                     callback(topic, payload, payloadLen);
                 } else {
                     // For QOS 1 and 2 we have a msgId (packet identifier) after the topic at the current payloadOffset
-                    // Guard 3: msgId must be addressable
-                    if (payloadLen < 2) {
-                        DEBUG_PSC_PRINTF("handlePacket(): Missing or out-of-bounds msgId in QoS 1/2\n");
+                    if (payloadLen < 2) {  // payload must be >= 2, as we have the msgId
+                        DEBUG_PSC_PRINTF("handlePacket(): Missing msgId in QoS 1/2 message\n");
                         return false;
                     }
                     uint8_t publishQos = MQTT_HDR_GET_QOS(_buffer[0]);  // save QoS before _buffer[0] is overwritten

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -916,6 +916,7 @@ PubSubClient& PubSubClient::setStream(Stream& stream) {
 bool PubSubClient::setBufferSize(size_t size) {
     // Buffer must be large enough to hold at least a minimal MQTT packet.
     if (size < MQTT_MIN_BUFFER_SIZE) {
+        // to save memory, allow to free the buffer if the client is disconnected and the size is set to 0
         if (_state == MQTT_DISCONNECTED && size == 0) {
             free(_buffer);
             _buffer = nullptr;

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -402,7 +402,7 @@ bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
                 } else {
                     // For QOS 1 and 2 we have a msgId (packet identifier) after the topic at the current payloadOffset
                     // Guard 3: msgId must be addressable
-                    if ((payloadLen < 2) || (payloadOffset + 2 + payloadLen > length)) {
+                    if (payloadLen < 2) {
                         DEBUG_PSC_PRINTF("handlePacket(): Missing or out-of-bounds msgId in QoS 1/2\n");
                         return false;
                     }

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -401,7 +401,7 @@ bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
                     callback(topic, payload, payloadLen);
                 } else {
                     // For QOS 1 and 2 we have a msgId (packet identifier) after the topic at the current payloadOffset
-                    if (payloadLen < 2) {  // payload must be >= 2, as we have the msgId
+                    if (payloadLen < 2) {  // payload must be >= 2, as we have the msgId before the actual payload
                         DEBUG_PSC_PRINTF("handlePacket(): Missing msgId in QoS 1/2 message\n");
                         return false;
                     }

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -388,9 +388,9 @@ bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
                 size_t payloadLen = length - payloadOffset;      // this might change by 2 if we have a QoS 1 or 2 message
                 uint8_t* payload = _buffer + payloadOffset;
 
-                // Guard 2: ensure topic and payload fit in buffer
-                if (payloadOffset + payloadLen > length) {
-                    DEBUG_PSC_PRINTF("handlePacket(): Topic and payload extend outside buffer\n");
+                // Guard 2: ensure topic fits in buffer
+                if (length < payloadOffset) {
+                    ERROR_PSC_PRINTF_P("handlePacket(): Suspicious topicLen (%u) points outside of received buffer length (%zu)\n", topicLen, length);
                     return false;
                 }
                 memmove(topic, topic + 1, topicLen);  // move topic inside buffer 1 byte to front
@@ -484,16 +484,9 @@ bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
 }
 
 bool PubSubClient::loop() {
-    if (!connected()) {
-        return false;
-    }
-    // Guard: buffer must exist and be large enough to hold any minimal MQTT packet
-    // (e.g. PINGREQ is 2 bytes, PUBACK/PUBREC responses are 4 bytes).
-    // This prevents readPacket() and handlePacket() from ever running with a null or
-    // undersized buffer. Note: MQTT_MAX_HEADER_SIZE (5) covers the worst-case fixed header.
-    if ((!_buffer) || (_bufferSize < MQTT_MAX_HEADER_SIZE)) {
-        return false;
-    }
+    if (!connected()) return false;
+    if (!_buffer) return false;  // do not crash if buffer allocation failed at construction
+
     bool ret = true;
     const unsigned long t = millis();
     if (_keepAliveMillis && ((t - _lastInActivity > _keepAliveMillis) || (t - _lastOutActivity > _keepAliveMillis))) {
@@ -921,8 +914,9 @@ PubSubClient& PubSubClient::setStream(Stream& stream) {
 }
 
 bool PubSubClient::setBufferSize(size_t size) {
-    if (size == 0) {
-        // Cannot set it back to 0
+    // Buffer must be large enough to hold at least a minimal MQTT packet.
+    // Note: MQTT_MAX_HEADER_SIZE (5) + protocol (9) + flags (1) + keepalive (2) covers a minmal CONNECT message.
+    if (size < MQTT_MAX_HEADER_SIZE + 9 + 1 + 2) {
         return false;
     }
     if (_bufferSize == 0) {

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -384,7 +384,7 @@ bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
                 }
                 uint16_t topicLen = (_buffer[hdrLen + 1] << 8) + _buffer[hdrLen + 2];  // topic length in bytes
                 char* topic = (char*)(_buffer + hdrLen + 3 - 1);                       // set the topic in the LSB of the topic lenght, as we move it there
-                size_t payloadOffset = hdrLen + 3ul + topicLen;  // payload starts after header and topic (if there is no packet identifier)
+                uint16_t payloadOffset = hdrLen + 3 + topicLen;  // payload starts after header and topic (if there is no packet identifier)
                 size_t payloadLen = length - payloadOffset;      // this might change by 2 if we have a QoS 1 or 2 message
                 uint8_t* payload = _buffer + payloadOffset;
 

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -359,7 +359,12 @@ size_t PubSubClient::readPacket(uint8_t* hdrLen) {
  */
 bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
     uint8_t type = _buffer[0] & 0xF0;
-    DEBUG_PSC_PRINTF("received message of type %u\n", type);
+    DEBUG_PSC_PRINTF("handlePacket(): received message of type %u\n", type);
+    if (length > _bufferSize) {
+        // This should never happen as readPacket() prevents buffer overflow, but we check again here to be sure and prevent any buffer overflows in the handling code.
+        DEBUG_PSC_PRINTF("handlePacket(): packet length %zu exceeds buffer size %zu\n", length, _bufferSize);
+        return false;
+    }
     switch (type) {
         case MQTTPUBLISH:
             if (callback) {
@@ -373,8 +378,8 @@ bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
                 // - Payload (for QoS > 0): length - (hdrLen + 5 + topicLen) bytes (starts at _buffer[hdrLen + 5 + topicLen])
                 // To get a null reminated 'C' topic string we move the topic 1 byte to the front (overwriting the LSB of the topic lenght)
                 // Guard 1: ensure topic length bytes are readable
-                if ((hdrLen + 2ul >= length) || (hdrLen + 2ul >= _bufferSize)) {
-                    ERROR_PSC_PRINTF_P("handlePacket(): Packet too short to contain topic length field\n");
+                if (hdrLen + 3ul > length) {
+                    DEBUG_PSC_PRINTF("handlePacket(): Packet too short to contain topic length field\n");
                     return false;
                 }
                 uint16_t topicLen = (_buffer[hdrLen + 1] << 8) + _buffer[hdrLen + 2];  // topic length in bytes
@@ -384,8 +389,8 @@ bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
                 uint8_t* payload = _buffer + payloadOffset;
 
                 // Guard 2: ensure topic and payload fit in buffer
-                if ((payloadOffset > _bufferSize) || (payloadOffset > length)) {
-                    ERROR_PSC_PRINTF_P("handlePacket(): Topic extends outside buffer/data\n");
+                if (payloadOffset + payloadLen > length) {
+                    DEBUG_PSC_PRINTF("handlePacket(): Topic and payload extend outside buffer\n");
                     return false;
                 }
                 memmove(topic, topic + 1, topicLen);  // move topic inside buffer 1 byte to front
@@ -397,8 +402,8 @@ bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
                 } else {
                     // For QOS 1 and 2 we have a msgId (packet identifier) after the topic at the current payloadOffset
                     // Guard 3: msgId must be addressable
-                    if ((payloadLen < 2) || (payloadOffset + 1 >= _bufferSize)) {
-                        ERROR_PSC_PRINTF_P("handlePacket(): Missing or out-of-bounds msgId in QoS 1/2\n");
+                    if ((payloadLen < 2) || (payloadOffset + 2 + payloadLen > length)) {
+                        DEBUG_PSC_PRINTF("handlePacket(): Missing or out-of-bounds msgId in QoS 1/2\n");
                         return false;
                     }
                     uint8_t publishQos = MQTT_HDR_GET_QOS(_buffer[0]);  // save QoS before _buffer[0] is overwritten

--- a/src/PubSubClient.cpp
+++ b/src/PubSubClient.cpp
@@ -217,6 +217,7 @@ bool PubSubClient::connect(const char* id, const char* user, const char* pass, c
 
 bool PubSubClient::connected() {
     if (!_client) return false;
+    if (!_buffer) return false;  // we can't be connected if we don't have a buffer to read into
 
     if (_client->connected()) {
         return (_state == MQTT_CONNECTED);
@@ -485,7 +486,6 @@ bool PubSubClient::handlePacket(uint8_t hdrLen, size_t length) {
 
 bool PubSubClient::loop() {
     if (!connected()) return false;
-    if (!_buffer) return false;  // do not crash if buffer allocation failed at construction
 
     bool ret = true;
     const unsigned long t = millis();
@@ -915,8 +915,13 @@ PubSubClient& PubSubClient::setStream(Stream& stream) {
 
 bool PubSubClient::setBufferSize(size_t size) {
     // Buffer must be large enough to hold at least a minimal MQTT packet.
-    // Note: MQTT_MAX_HEADER_SIZE (5) + protocol (9) + flags (1) + keepalive (2) covers a minmal CONNECT message.
-    if (size < MQTT_MAX_HEADER_SIZE + 9 + 1 + 2) {
+    if (size < MQTT_MIN_BUFFER_SIZE) {
+        if (_state == MQTT_DISCONNECTED && size == 0) {
+            free(_buffer);
+            _buffer = nullptr;
+            _bufferSize = 0;
+            return true;
+        }
         return false;
     }
     if (_bufferSize == 0) {

--- a/src/PubSubClient.h
+++ b/src/PubSubClient.h
@@ -128,8 +128,12 @@
 /// \endcond
 /** @} */
 
-/// \cond Maximum size of fixed header and variable length size header
+/// \cond
+// Maximum size of fixed header and variable length size header
 #define MQTT_MAX_HEADER_SIZE 5
+// Minimal buffer size that can be handled, used to check if the buffer size is sufficient in setBufferSize().
+// MQTT_MAX_HEADER_SIZE (5) + protocol (9) + flags (1) + keepalive (2) covers a minmal CONNECT message
+#define MQTT_MIN_BUFFER_SIZE (MQTT_MAX_HEADER_SIZE + 9 + 1 + 2)
 /// \endcond
 
 /// \anchor callback


### PR DESCRIPTION
Applied safety checks introduced by @MarcAntoineCRUE in #91 
- connect(): null-buffer guard to prevent crash if buffer allocation failed
- disconnect(): null-buffer guard
- loop(): buffer existence and size validation before packet processing
- handlePacket(): three ordered boundary checks for topic length, payload offset, and msgId fields
- Detailed error messages with context for debugging